### PR TITLE
Add title directive to API reference index

### DIFF
--- a/docs/source/api_reference/generated/simpm.dashboard.build_app.rst
+++ b/docs/source/api_reference/generated/simpm.dashboard.build_app.rst
@@ -1,4 +1,4 @@
-﻿simpm.dashboard.build\_app
+simpm.dashboard.build\_app
 ==========================
 
 .. currentmodule:: simpm.dashboard

--- a/docs/source/api_reference/generated/simpm.dashboard.run_post_dashboard.rst
+++ b/docs/source/api_reference/generated/simpm.dashboard.run_post_dashboard.rst
@@ -1,4 +1,4 @@
-﻿simpm.dashboard.run\_post\_dashboard
+simpm.dashboard.run\_post\_dashboard
 ====================================
 
 .. currentmodule:: simpm.dashboard

--- a/docs/source/api_reference/generated/simpm.des.rst
+++ b/docs/source/api_reference/generated/simpm.des.rst
@@ -1,4 +1,4 @@
-﻿simpm.des
+simpm.des
 =========
 
 .. automodule:: simpm.des

--- a/docs/source/api_reference/generated/simpm.dist.rst
+++ b/docs/source/api_reference/generated/simpm.dist.rst
@@ -1,4 +1,4 @@
-﻿simpm.dist
+simpm.dist
 ==========
 
 .. automodule:: simpm.dist

--- a/docs/source/api_reference/generated/simpm.log_cfg.rst
+++ b/docs/source/api_reference/generated/simpm.log_cfg.rst
@@ -1,4 +1,4 @@
-﻿simpm.log\_cfg
+simpm.log\_cfg
 ==============
 
 .. automodule:: simpm.log_cfg

--- a/docs/source/api_reference/index.rst
+++ b/docs/source/api_reference/index.rst
@@ -1,3 +1,5 @@
+.. title:: API Reference
+
 API Reference
 =============
 

--- a/docs/source/generated/simpm.dashboard.rst
+++ b/docs/source/generated/simpm.dashboard.rst
@@ -1,4 +1,4 @@
-﻿simpm.dashboard
+simpm.dashboard
 ===============
 
 .. automodule:: simpm.dashboard

--- a/docs/source/generated/simpm.des.rst
+++ b/docs/source/generated/simpm.des.rst
@@ -1,4 +1,4 @@
-﻿simpm.des
+simpm.des
 =========
 
 .. automodule:: simpm.des

--- a/docs/source/generated/simpm.dist.rst
+++ b/docs/source/generated/simpm.dist.rst
@@ -1,4 +1,4 @@
-﻿simpm.dist
+simpm.dist
 ==========
 
 .. automodule:: simpm.dist

--- a/docs/source/generated/simpm.log_cfg.rst
+++ b/docs/source/generated/simpm.log_cfg.rst
@@ -1,4 +1,4 @@
-﻿simpm.log\_cfg
+simpm.log\_cfg
 ==============
 
 .. automodule:: simpm.log_cfg


### PR DESCRIPTION
## Summary
- add an explicit title directive to the API reference index page so Sphinx records the page title

## Testing
- make -C docs html


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6940e6e6f09c8332a84166efc6e861f3)